### PR TITLE
ワークフロー修正

### DIFF
--- a/.github/workflows/make-draft-commit.yml
+++ b/.github/workflows/make-draft-commit.yml
@@ -1,4 +1,4 @@
-name: ドラフト作成
+name: ドラフト作成（コミットあり）
 on:
     workflow_dispatch:
         inputs:
@@ -37,8 +37,12 @@ jobs:
                   MODEL: ${{ vars.CURSOR_MODEL || 'gpt-5' }}
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  # AIにコード変更を指示
-                  cursor-agent --force --api-key "$CURSOR_API_KEY" --output-format=text --print "プロジェクトの改善のために、README.mdファイルを作成または更新し、プロジェクトの概要を日本語で記述してください。また、必要に応じて他のファイルも改善してください。" > ai_changes.txt
+                  # AIにファイル変更のみを指示（制限付きアプローチ）
+                  cursor-agent -p "重要: ブランチの作成、コミット、プッシュ、またはPRへのコメント投稿はしないでください。
+                  作業ディレクトリ内のファイルのみを変更してください。公開は後続のワークフローステップが実行します。
+
+                  プロジェクトの改善のために、README.mdファイルを作成または更新し、プロジェクトの概要を日本語で記述してください。
+                  このプロジェクトはJava Spring Bootアプリケーションです。"
 
                   # 変更されたファイルを特定
                   echo "変更されたファイルを確認中..."
@@ -73,8 +77,9 @@ jobs:
                   MODEL: ${{ vars.CURSOR_MODEL || 'gpt-5' }}
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  # PRの説明を生成
-                  cursor-agent --force --api-key "$CURSOR_API_KEY" --output-format=text --print "このコミットで行った変更について、技術者向けに詳しく説明してください。どのような改善が行われ、どのような影響があるかを記述してください。" > pr_description.txt
+                  # 変更されたファイルの内容を分析してPR説明を生成
+                  cursor-agent -p "変更されたファイルを分析して、技術者向けに詳しく説明してください。
+                  このプロジェクトはJava Spring Bootアプリケーションです。どのような改善が行われ、どのような影響があるかを記述してください。" > pr_description.txt
 
             - name: Create Draft Pull Request
               env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines the draft PR workflow to restrict the AI to local file edits, auto-commit changes, and create guarded draft PRs with improved descriptions.
> 
> - **CI/CD** (`.github/workflows/make-draft-commit.yml`):
>   - **Workflow**: Rename to `ドラフト作成（コミットあり）`; add `draft_title` input and default `base_branch: main`.
>   - **AI step**: Replace prompt with a restricted, file-edit-only instruction tailored for a Java Spring Boot project.
>   - **Commit step**: New step to commit AI-made changes only when diffs exist, with a structured commit message.
>   - **PR description**: Generate from analyzed changed files instead of a generic prompt.
>   - **PR creation**: 
>     - Skip when no changes detected.
>     - Enforce current branch matches `inputs.head_branch`.
>     - Support dynamic title (use `draft_title` or timestamped default).
>     - Build a richer PR body including AI changes, detailed description, and changed files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84cd8ac3583cc629c969c8469c68f4d1a31c6cda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->