### PR TITLE
プッシュを追加

### DIFF
--- a/.github/workflows/make-draft-commit.yml
+++ b/.github/workflows/make-draft-commit.yml
@@ -48,6 +48,8 @@ jobs:
                   git status --porcelain > changed_files.txt
 
             - name: Commit AI Changes
+              env:
+                  HEAD_BRANCH: ${{ inputs.head_branch }}
               run: |
                   # Git設定
                   git config --global user.name "github-actions[bot]"
@@ -66,6 +68,11 @@ jobs:
 
                    変更内容の詳細はPRの説明をご確認ください。"
                     echo "コミットが作成されました。"
+
+                    # コミットをプッシュ
+                    echo "コミットをプッシュします..."
+                    git push origin $HEAD_BRANCH
+                    echo "プッシュが完了しました。"
                   else
                     echo "変更されたファイルがありません。コミットをスキップします。"
                   fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a push step to send committed AI changes to the `inputs.head_branch` in the draft PR workflow.
> 
> - **CI/CD** (`.github/workflows/make-draft-commit.yml`):
>   - **Commit AI Changes**:
>     - Exposes `HEAD_BRANCH` from `inputs.head_branch`.
>     - Pushes committed changes to `origin $HEAD_BRANCH` after commit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4251d6b6eca4da6be4e2a8b82e216df79ba80ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->